### PR TITLE
Add Locality, AdministrativeArea and PostalCode

### DIFF
--- a/android/src/main/kotlin/com/kiwi/reversegeocode/RNReverseGeocodeManager.kt
+++ b/android/src/main/kotlin/com/kiwi/reversegeocode/RNReverseGeocodeManager.kt
@@ -47,10 +47,13 @@ class RNReverseGeocodeManager (reactContext: ReactApplicationContext) : ReactCon
 
   private fun formatAddress(address: Address): WritableMap {
     val addressObject = WritableNativeMap()
-    
     addressObject.putString("name", address.getFeatureName())
     addressObject.putMap("location", getLocationFromAddress(address))
     addressObject.putString("address", getFirstLineOfAddress(address))
+    addressObject.putString("locality", address.getLocality())
+    addressObject.putString("administrativeArea", address.getAdminArea())
+    addressObject.putString("postalCode", address.getPostalCode())
+
     
     return addressObject
   }

--- a/ios/RNReverseGeocode.m
+++ b/ios/RNReverseGeocode.m
@@ -54,6 +54,9 @@ RCT_EXPORT_MODULE()
         
         [formedLocation setValue:mapItem.name forKey:@"name"];
         [formedLocation setValue:mapItem.placemark.title forKey:@"address"];
+        [formedLocation setValue:mapItem.placemark.locality forKey:@"locality"];
+        [formedLocation setValue:mapItem.placemark.postalCode forKey:@"postalCode"];
+        [formedLocation setValue:mapItem.placemark.administrativeArea forKey:@"administrativeArea"];
         [formedLocation setValue:@{@"latitude": @(mapItem.placemark.coordinate.latitude),
                                    @"longitude": @(mapItem.placemark.coordinate.longitude)} forKey:@"location"];
         


### PR DESCRIPTION
This PR adds `locality`, `administrativeArea` and `postalCode` to the returned results from both Android and iOS location searching.